### PR TITLE
Add GitHub Funding Configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github: [mbround18] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: mbround18 # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: mbround18 # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: ["https://paypal.me/MichaelBruno"]


### PR DESCRIPTION
This PR adds a FUNDING.yml file to help support the maintainer(s) of this project.

This file configuration allows GitHub to display sponsor information on your repository.